### PR TITLE
Add `quote` and `join`

### DIFF
--- a/shellwords.cabal
+++ b/shellwords.cabal
@@ -28,6 +28,8 @@ source-repository head
 library
   exposed-modules:
       ShellWords
+      ShellWords.Parse
+      ShellWords.Quote
       Text.Megaparsec.Compat
   other-modules:
       Paths_shellwords
@@ -50,7 +52,8 @@ test-suite hspec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
-      ShellWordsSpec
+      ShellWords.ParseSpec
+      ShellWords.QuoteSpec
       Paths_shellwords
   hs-source-dirs:
       test

--- a/src/ShellWords.hs
+++ b/src/ShellWords.hs
@@ -1,8 +1,11 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module ShellWords
-  ( parse
+  ( -- * Splitting shell words
+    parse
   , parseText
+
+    -- * Quoting for shells
+  , quote
+  , join
 
     -- * Low-level parser
   , Parser
@@ -10,68 +13,14 @@ module ShellWords
   , parser
   ) where
 
-import Prelude
-
-import Data.Bifunctor (first)
-import Data.Char
-import Data.Text (Text, pack, unpack)
-import Data.Void (Void)
-import qualified Text.Megaparsec as Megaparsec
-import Text.Megaparsec.Char
-import Text.Megaparsec.Compat hiding (parse, runParser)
-
-type Parser = Parsec Void String
-
-parse :: String -> Either String [String]
-parse = runParser parser
-
-runParser :: Parser a -> String -> Either String a
-runParser p = first errorBundlePretty . Megaparsec.parse (p <* eof) "<input>"
-
--- | Parse and return @'Text'@ values
-parseText :: Text -> Either String [Text]
-parseText = fmap (map pack) . parse . unpack
-
-parser :: Parser [String]
-parser = space *> shellword `sepEndBy1` space1 <* space
-
-shellword :: Parser String
-shellword = fmap concat $ some $ bare <|> quoted
-
--- | A plain value, here till an (unescaped) space or quote
-bare :: Parser String
-bare = some go
- where
-  go =
-    escaped '\\'
-      <|> escapedSpace
-      <|> escapedAnyOf (reserved <> quotes)
-      <|> satisfy ((&&) <$> not . isSpace <*> (`notElem` (reserved <> quotes)))
-      <?> "non white space / non reserved character / non quote"
-
--- | A balanced, single- or double-quoted string
-quoted :: Parser String
-quoted = do
-  q <- oneOf quotes
-  manyTill (escaped '\\' <|> escaped q <|> anyToken) $ char q
-
-escaped :: Char -> Parser Char
-escaped c = c <$ (escapedSatisfy (== c) <?> "escaped" <> show c)
-
-escapedSpace :: Parser Char
-escapedSpace = escapedSatisfy isSpace <?> "escaped white space"
-
-escapedAnyOf :: [Char] -> Parser Char
-escapedAnyOf cs = escapedSatisfy (`elem` cs) <?> "escaped one of " <> cs
-
-escapedSatisfy :: (Char -> Bool) -> Parser Char
-escapedSatisfy p = try $ string "\\" *> satisfy p
-
-anyToken :: Parser Char
-anyToken = satisfy $ const True
-
-reserved :: [Char]
-reserved = "();"
-
-quotes :: [Char]
-quotes = "\'\""
+import ShellWords.Parse
+    ( parse
+    , parseText
+    , Parser
+    , runParser
+    , parser
+    )
+import ShellWords.Quote
+    ( quote
+    , join
+    )

--- a/src/ShellWords/Parse.hs
+++ b/src/ShellWords/Parse.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ShellWords.Parse
+  ( -- * Splitting shell words
+    parse
+  , parseText
+
+    -- * Low-level parser
+  , Parser
+  , runParser
+  , parser
+  ) where
+
+import Prelude
+
+import Data.Bifunctor (first)
+import Data.Char
+import Data.Text (Text, pack, unpack)
+import Data.Void (Void)
+import qualified Text.Megaparsec as Megaparsec
+import Text.Megaparsec.Char
+import Text.Megaparsec.Compat hiding (parse, runParser)
+
+type Parser = Parsec Void String
+
+parse :: String -> Either String [String]
+parse = runParser parser
+
+runParser :: Parser a -> String -> Either String a
+runParser p = first errorBundlePretty . Megaparsec.parse (p <* eof) "<input>"
+
+-- | Parse and return @'Text'@ values
+parseText :: Text -> Either String [Text]
+parseText = fmap (map pack) . parse . unpack
+
+parser :: Parser [String]
+parser = space *> shellword `sepEndBy1` space1 <* space
+
+shellword :: Parser String
+shellword = fmap concat $ some $ bare <|> quoted
+
+-- | A plain value, here till an (unescaped) space or quote
+bare :: Parser String
+bare = some go
+ where
+  go =
+    escaped '\\'
+      <|> escapedSpace
+      <|> escapedAnyOf (reserved <> quotes)
+      <|> satisfy ((&&) <$> not . isSpace <*> (`notElem` (reserved <> quotes)))
+      <?> "non white space / non reserved character / non quote"
+
+-- | A balanced, single- or double-quoted string
+quoted :: Parser String
+quoted = do
+  q <- oneOf quotes
+  manyTill (escaped '\\' <|> escaped q <|> anyToken) $ char q
+
+escaped :: Char -> Parser Char
+escaped c = c <$ (escapedSatisfy (== c) <?> "escaped" <> show c)
+
+escapedSpace :: Parser Char
+escapedSpace = escapedSatisfy isSpace <?> "escaped white space"
+
+escapedAnyOf :: [Char] -> Parser Char
+escapedAnyOf cs = escapedSatisfy (`elem` cs) <?> "escaped one of " <> cs
+
+escapedSatisfy :: (Char -> Bool) -> Parser Char
+escapedSatisfy p = try $ string "\\" *> satisfy p
+
+anyToken :: Parser Char
+anyToken = satisfy $ const True
+
+reserved :: [Char]
+reserved = "();"
+
+quotes :: [Char]
+quotes = "\'\""

--- a/src/ShellWords/Quote.hs
+++ b/src/ShellWords/Quote.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module ShellWords.Quote
+  (-- * Quoting for shells
+    quote
+  , join
+  ) where
+
+import Prelude
+
+-- | How to escape a `String` for @sh(1)@.
+data EscapeStyle
+  = -- | No escaping.
+    NoEscaping
+  | -- | Wrapped in single quotes.
+    SingleQuoted
+  | -- | Wrapped in single quotes
+    Mixed
+
+-- | Internal state for `escapeStyle`.
+data EscapeStyleState =
+  EscapeStyleState
+  { hasSpecial :: Bool
+  , hasNewline :: Bool
+  , hasSingleQuote :: Bool
+  }
+
+-- | Determine how to escape a `String`.
+escapeStyle :: String -> EscapeStyle
+escapeStyle "" = SingleQuoted
+escapeStyle str =
+  let
+    isOtherSpecial :: Char -> Bool
+    isOtherSpecial c = c `elem` ("|&;<>()$`\\\" \t*?[#~=%" :: String)
+
+    helper :: EscapeStyleState -> String -> EscapeStyle
+    helper state (c : s)
+      | c == '\n' = helper state {hasNewline = True, hasSpecial = True} s
+      | c == '\'' = helper state {hasSingleQuote = True, hasSpecial = True} s
+      | isOtherSpecial c = helper state {hasSpecial = True} s
+      | otherwise = helper state s
+    helper EscapeStyleState {hasSpecial, hasNewline, hasSingleQuote} []
+      | not hasSpecial = NoEscaping
+      | hasNewline && not hasSingleQuote = SingleQuoted
+      | otherwise = Mixed
+  in
+    helper
+      EscapeStyleState
+        { hasSpecial = False
+        , hasNewline = False
+        , hasSingleQuote = False
+        }
+      str
+
+-- | Escape special characters in a string, so that it will retain its literal
+-- meaning when used as a part of command in a Unix shell.
+--
+-- It tries to avoid introducing any unnecessary quotes or escape characters,
+-- but specifics regarding quoting style are left unspecified.
+quote :: String -> String
+quote str =
+  case escapeStyle str of
+    NoEscaping -> str
+    SingleQuoted -> "'" <> str <> "'"
+    Mixed ->
+      let
+        quoteMixed :: String -> String
+        quoteMixed [] = []
+        quoteMixed ('\'' : s) = "'\\''" <> quoteMixed s
+        quoteMixed (c : s) = c : quoteMixed s
+      in
+        "'" <> quoteMixed str <> "'"
+
+-- | Joins arguments into a single command line suitable for execution in a Unix shell.
+--
+-- Each argument is quoted using `quote` to preserve its literal meaning when
+-- parsed by Unix shell.
+--
+-- Note: This function is essentially an (infallible) inverse of `parse`.
+join :: [String] -> String
+join = unwords . map quote

--- a/test/ShellWords/ParseSpec.hs
+++ b/test/ShellWords/ParseSpec.hs
@@ -6,14 +6,14 @@
 -- Case-for-case port from Python:
 --
 -- <https://github.com/mozillazg/python-shellwords/blob/master/tests/test_shellwords.py>
-module ShellWordsSpec
+module ShellWords.ParseSpec
   ( spec
   ) where
 
 import Prelude hiding (truncate)
 
 import Data.Foldable (for_, traverse_)
-import ShellWords
+import ShellWords.Parse (runParser, parser)
 import Test.Hspec
 import Text.Megaparsec.Char (string)
 import Text.Megaparsec.Compat (between)

--- a/test/ShellWords/QuoteSpec.hs
+++ b/test/ShellWords/QuoteSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+--
+-- Some test cases ported from Rust:
+--
+-- <https://github.com/tmiasko/shell-words/blob/045e4dccd2478ccc8bfa91bd0fe449dfe5473496/src/lib.rs#L475-L488>
+module ShellWords.QuoteSpec
+  ( spec
+  ) where
+
+import Prelude hiding (truncate)
+
+import ShellWords.Quote (quote, join)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "quote" $ do
+    it "single-quotes the empty string" $ do
+      quote "" `shouldBe` "''"
+
+    it "escapes a single quote" $ do
+      quote "'" `shouldBe` "''\\'''"
+
+    it "leaves un-special characters alone" $ do
+      quote "abc" `shouldBe` "abc"
+
+    it "quotes newlines" $ do
+      quote "a \n  b" `shouldBe` "'a \n  b'"
+
+    it "quotes newlines and escapes single-quotes" $ do
+      quote "X'\nY" `shouldBe` "'X'\\''\nY'"
+
+    it "quotes tildes correctly" $ do
+      quote "~root" `shouldBe` "'~root'"
+
+  describe "join" $ do
+    it "joins arguments" $ do
+      join ["a", "b", "c"] `shouldBe` "a b c"
+
+    it "quotes arguments" $ do
+      join [" ", "$", "\n"] `shouldBe` "' ' '$' '\n'"


### PR DESCRIPTION
`quote` and `join` escape text for usage in a shell or display to a user. They are roughly an inverse of `parse`.

These functions match similar interfaces available in Rust (as [`shell_words::quote`](https://docs.rs/shell-words/latest/shell_words/fn.quote.html)/`join`) and Python (as [`shlex.quote`](https://docs.python.org/3/library/shlex.html#shlex.quote)/`join`).

I also added a `build-tool-depends` for `hspec-discover` so that I could run the test suite.