### PR TITLE
Add `build-tool-depends: hspec-discover`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -59,4 +59,4 @@ tests:
       - shellwords
       - megaparsec
     build-tools:
-      - hspec-discover:hspec-discover
+      - hspec-discover

--- a/package.yaml
+++ b/package.yaml
@@ -58,3 +58,5 @@ tests:
       - hspec
       - shellwords
       - megaparsec
+    build-tools:
+      - hspec-discover:hspec-discover

--- a/shellwords.cabal
+++ b/shellwords.cabal
@@ -60,6 +60,8 @@ test-suite hspec
   default-extensions:
       NoImplicitPrelude
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       base <5
     , hspec


### PR DESCRIPTION
Fixes an error when running tests:

```
$ cabal test
Build profile: -w ghc-9.6.6 -O1
In order, the following will be built (use -v for more details):
 - shellwords-0.1.3.2 (test:hspec) (first run)
Preprocessing test suite 'hspec' for shellwords-0.1.3.2...
Building test suite 'hspec' for shellwords-0.1.3.2...
ghc-9.6.6: could not execute: hspec-discover
```

Split off of #11, see https://github.com/pbrisbin/hs-shellwords/pull/11#discussion_r1884024753