### PR TITLE
Don't check out head.ref in Restyled workflow

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - uses: restyled-io/actions/setup@v4
       - uses: restyled-io/actions/run@v4
         with:


### PR DESCRIPTION
This fails on forks because the origin/branch ref doesn't existing in the repository. Checking out pulls/n/head may work but since the repository is not busy and the default pulls/n/merge code is almost certainly the same code, we'll just do that.